### PR TITLE
fix: glyph fitting in texture

### DIFF
--- a/src_lib_generator/generator.cpp
+++ b/src_lib_generator/generator.cpp
@@ -128,7 +128,11 @@ long Generator::fitGlyphsToTexture()
         cerr << "Area [X: " << X << " , Y: " << Y << "]\n";
     }
 
-    auto factor = (float)mConf.outputTextureSize() / max( (float)X, (float)Y );
+    // Consider a 1 pixel margin per glyph, to account for rounding errors
+    auto factorX = (float)(mConf.outputTextureSize() - numItemsPerRow) / (float)X;
+    auto nbRows = (mGlyphs.size() + numItemsPerRow - 1) / numItemsPerRow;
+    auto factorY = (float)(mConf.outputTextureSize() - nbRows) / (float)Y;
+    auto factor = min(factorX, factorY);
     mConf.setGlyphScalingFromSamplingToPackedSignedDist( factor );
 
     findDimension ( numItemsPerRow, X, Y );

--- a/src_lib_generator/internal_glyph_for_generator.cpp
+++ b/src_lib_generator/internal_glyph_for_generator.cpp
@@ -42,8 +42,8 @@ InternalGlyphForGen::InternalGlyphForGen (
     mSignedDistBaseX    ( 0 ),
     mSignedDistBaseY    ( 0 )
 {
-    mSignedDistWidth  = ceil( (float)mWidth  * ( 1.0f + 2.0f * mConf.ratioSpreadToGlyph() ) );
-    mSignedDistHeight = ceil( (float)mHeight * ( 1.0f + 2.0f * mConf.ratioSpreadToGlyph() ) );
+    mSignedDistWidth  = ceil( (float)mWidth + 2.0f * mConf.signedDistExtent() );
+    mSignedDistHeight = ceil( (float)mHeight + 2.0f * mConf.signedDistExtent() );
 }
 
 
@@ -326,8 +326,8 @@ void InternalGlyphForGen::setSignedDist( FT_Bitmap& bm ) {
 
     const long spreadInBitmapPixels = (long)( mConf.ratioSpreadToGlyph() * (float)mConf.glyphBitmapSizeForSampling() );
 
-    mSignedDistWidth  = mWidth  * scale + 2 * mConf.signedDistExtent();
-    mSignedDistHeight = mHeight * scale + 2 * mConf.signedDistExtent();
+    mSignedDistWidth  = ceil(mWidth  * scale + 2 * mConf.signedDistExtent());
+    mSignedDistHeight = ceil(mHeight * scale + 2 * mConf.signedDistExtent());
 
     size_t arraySize = mSignedDistWidth * mSignedDistHeight;
 


### PR DESCRIPTION
Sometimes, depending on the parameters, the font doesn't fit the texture, making the result unusable.

This pull request is to fix this issue:

- Used signedDistExtent() instead of mHeight/mWidth * ratioSpreadToGlyph() for initial glyph size calculation, to match computation in setSignedDist()

- Added a ceil() to final glyph size calculation, to avoid potential overlap caused by rounding errors

- For scale factor computation, reduce texture width/height by 1 pixel per glyph, to avoid exceeding boundaries because of rounding errors